### PR TITLE
Get Latest Emoji Data By Refactoring How We Fetch Emojis

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"@vue/cli-service": "^4.5.13",
 		"axios": "^0.21.1",
 		"emoji-name-map": "^1.2.9",
+		"emojibase": "^6.1.0",
 		"fuse.js": "^6.4.6",
 		"vue": "^3.0.0"
 	},

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,7 +69,7 @@ import emojiCard from './components/emojiCard.vue';
 // inspiration for this implementation is from Sebastian Aigner's twemoji-amazing
 // 	(https://github.com/SebastianAigner/twemoji-amazing/tree/master/src/main/kotlin)
 import Fuse from 'fuse.js';
-import { fetchEmojiInfo } from './fetcher';
+import { fetchEmojiInfo } from './fetcher.js';
 
 export default {
 	name: 'App',
@@ -115,30 +115,18 @@ export default {
 	},
 	mounted() {
 		fetchEmojiInfo().then((data) => {
-			let emojiMap = require('emoji-name-map').emoji;
-			let emojiArray = [];
-			Object.keys(emojiMap).forEach((key) => {
-				// console.log	(key);
-				let emojiCode = data.find((x) => x.char === emojiMap[key]);
-				if (emojiCode === undefined) return;
-				emojiCode = emojiCode.codes;
-				emojiArray.push({
-					name: key.replaceAll('_', ' '),
-					emoji: emojiMap[key],
-					url: {
-						png: `https://twemoji.maxcdn.com/v/latest/72x72/${emojiCode}.png`,
-						svg: `https://twemoji.maxcdn.com/v/latest/svg/${emojiCode}.svg`,
-					},
-					cp: emojiCode,
-				});
-			});
-
-			this.emojiArray = emojiArray;
-			this.charInfos = data;
-			this.fuzzy = new Fuse(emojiArray, {
+			data = data.map((e) => ({
+				...e,
+				url: {
+					png: `https://twemoji.maxcdn.com/v/latest/72x72/${e.hexcode.toLowerCase()}.png`,
+					svg: `https://twemoji.maxcdn.com/v/latest/svg/${e.hexcode.toLowerCase()}.svg`,
+				}
+			}));
+			this.fuzzy = new Fuse(data, {
 				threshold: 0.2,
-				keys: ['name'],
+				keys: ['label'],
 			});
+			this.emojis = data;
 			this.loading = false;
 		});
 	},

--- a/src/App.vue
+++ b/src/App.vue
@@ -58,10 +58,10 @@
 import emojiCard from './components/emojiCard.vue';
 // current idea on how to implement this thing
 // 1. we get all code points and emoji info
-//	  (https://api.github.com/repos/twitter/twemoji/git/trees/fc6688975af4c908eae5a144f6df6e71bdb8a428)
-// 	  (https://unpkg.com/emoji.json/emoji.json)
-// 2. get the search bar then we map all the emojis from `emoji-name-map` to what the user
-//    is searching
+//	  (https://api.github.com/repos/twitter/twemoji/git/trees/master?recursive=1 then filter)
+// 	  (https://emojibase.dev/)
+// 2. get the search bar then we map all the emojis from emojibase's shortcodes
+//    to what the user is searching
 // 3. we get all the code points of the map from the emoji info
 // 4. check/convert if it's a valid code point with the code points we got
 // 5. make a object with the links for the downloadable emojis https://twemoji.maxcdn.com/v/latest/svg/{codes}.svg

--- a/src/components/emojiCard.vue
+++ b/src/components/emojiCard.vue
@@ -3,7 +3,7 @@
 		<img :src="info.url.png" />
 		<div class="text">
 			<!-- add underlines with no redirects lmao-->
-			<a>{{ info.name }}</a>
+			<a>{{ info.label }}</a>
 		</div>
 		<br />
 		<div class="btns">

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1,6 +1,7 @@
-const axios = require('axios');
+import { fetchEmojis } from 'emojibase';
+import axios from 'axios';
 
-async function getEmojiCodes() {
+export async function getEmojiCodes() {
 	// getting all emoji codes from twemoji github
 	let res = await axios.get(
 		'https://api.github.com/repos/twitter/twemoji/git/trees/master?recursive=1'
@@ -13,26 +14,15 @@ async function getEmojiCodes() {
 	return emojiCodes;
 }
 
-async function fetchEmojiInfo() {
+export async function fetchEmojiInfo() {
 	let emojiCodes = await getEmojiCodes();
-	console.log(emojiCodes);
 	// getting all emoji info
-	const res = await axios.get(
-		'https://unpkg.com/emoji.json@13.1.0/emoji.json'
-	);
-	let data = res.data;
-	for (let item of data) {
-		item.name = item.name.replace(/:?\s/g, '_');
-		item.codes = item.codes.toLowerCase().replace(/\s/g, '-');
-	}
+	let data = await fetchEmojis('en', {
+		shortcodes: ['cldr'],
+	});
 	// delete the emojis that doesn't exist on twemoji
 	data = data.filter(function (item) {
-		return emojiCodes.includes(item.codes);
+		return emojiCodes.includes(item.hexcode.toLowerCase());
 	});
 	return data;
 }
-
-module.exports = {
-	fetchEmojiInfo,
-	getEmojiCodes,
-};

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -3,26 +3,30 @@ const axios = require('axios');
 async function getEmojiCodes() {
 	// getting all emoji codes from twemoji github
 	let res = await axios.get(
-		'https://api.github.com/repos/twitter/twemoji/git/trees/fc6688975af4c908eae5a144f6df6e71bdb8a428'
+		'https://api.github.com/repos/twitter/twemoji/git/trees/master?recursive=1'
 	);
 	let emojiCodes = [];
 	for (let x of res.data.tree) {
-		emojiCodes.push(x.path.substring(0, x.path.length - 4));
+		if (x.path.startsWith('assets/svg/'))
+			emojiCodes.push(x.path.substring(11, x.path.length - 4));
 	}
 	return emojiCodes;
 }
 
 async function fetchEmojiInfo() {
 	let emojiCodes = await getEmojiCodes();
+	console.log(emojiCodes);
 	// getting all emoji info
-	const res = await axios.get('https://unpkg.com/emoji.json@13.1.0/emoji.json');
+	const res = await axios.get(
+		'https://unpkg.com/emoji.json@13.1.0/emoji.json'
+	);
 	let data = res.data;
 	for (let item of data) {
 		item.name = item.name.replace(/:?\s/g, '_');
 		item.codes = item.codes.toLowerCase().replace(/\s/g, '-');
 	}
 	// delete the emojis that doesn't exist on twemoji
-	data = data.filter(function(item) {
+	data = data.filter(function (item) {
 		return emojiCodes.includes(item.codes);
 	});
 	return data;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,6 +3038,7 @@ __metadata:
     "@vue/composition-api": ^1.0.4
     axios: ^0.21.1
     emoji-name-map: ^1.2.9
+    emojibase: ^6.1.0
     fuse.js: ^6.4.6
     vue: ^3.0.0
   languageName: unknown
@@ -3065,6 +3066,13 @@ __metadata:
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: 87cf3f89efb8ba028075b3dc1713e2c5609af94cbc129b1f00c3113d01dbe4bf85c9d971e75a98bf8a8508131727682ce929e4bd70e9022af4fd47d75e9507de
+  languageName: node
+  linkType: hard
+
+"emojibase@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "emojibase@npm:6.1.0"
+  checksum: 0891f608db7134f02cf7fe62b2cd7e7a3561d17401217954a702231d8779099400522a79292e5ebd0219b9928785bf205aa6d8db754b9ec7c9d9657901516a36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The code is currently stuck on unicode 13 since it's essentially forced to given the links it fetches.

Using the most recent git trees from the Twemoji repository and Emojibase, we can get the latest emoji data without manually changing code every new unicode update.